### PR TITLE
Removed python language from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: required
 services:
   - docker
 
-language: python
-python: 2.7
-
 before_install:
     - docker pull palpitate/palpitate-image
 


### PR DESCRIPTION
There is no need for the python language in travis as all of the tests are run inside the docker instance. This import could confuse someone in the future, making them run their tests outside of travis.
